### PR TITLE
ci: build and publish custom Multiplayer images

### DIFF
--- a/.github/workflows/build-images-multiplayer.yml
+++ b/.github/workflows/build-images-multiplayer.yml
@@ -1,0 +1,14 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+name: Test image generation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_images:
+    if: github.repository == 'multiplayer-app/opentelemetry-demo'
+    uses: ./.github/workflows/component-build-images-multiplayer.yml

--- a/.github/workflows/component-build-images-multiplayer.yml
+++ b/.github/workflows/component-build-images-multiplayer.yml
@@ -1,0 +1,195 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: Should the images be pushed
+        default: false
+        required: false
+        type: boolean
+      version:
+        description: The version used when tagging the image
+        default: 'dev'
+        required: false
+        type: string
+      ghcr_repo:
+        description: GHCR repository
+        default: 'ghcr.io/multiplayer-app/demo'
+        required: false
+        type: string
+
+jobs:
+  protobufcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate
+        run: make clean docker-generate-protobuf
+      - name: Check Clean Work Tree
+        run: make check-clean-work-tree
+
+  build_and_push_images:
+    runs-on: ubuntu-latest
+    needs: protobufcheck
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      RELEASE_VERSION: "${{ github.event.release.tag_name }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        file_tag:
+          - file: ./src/accounting/Dockerfile
+            tag_suffix: accounting
+            context: ./
+            setup-qemu: true
+          - file: ./src/adservice/Dockerfile
+            tag_suffix: adservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/cartservice/src/Dockerfile
+            tag_suffix: cartservice
+            context: ./
+            setup-qemu: false
+          - file: ./src/checkoutservice/Dockerfile
+            tag_suffix: checkoutservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/currencyservice/Dockerfile
+            tag_suffix: currencyservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/emailservice/Dockerfile
+            tag_suffix: emailservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/frauddetectionservice/Dockerfile
+            tag_suffix: frauddetectionservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/frontend/Dockerfile
+            tag_suffix: frontend
+            context: ./
+            setup-qemu: true
+          - file: ./src/frontendproxy/Dockerfile
+            tag_suffix: frontendproxy
+            context: ./
+            setup-qemu: true
+          - file: ./src/frontend/Dockerfile.cypress
+            tag_suffix: frontend-tests
+            context: ./
+            setup-qemu: true
+          - file: ./src/imageprovider/Dockerfile
+            tag_suffix: imageprovider
+            context: ./
+            setup-qemu: true
+          - file: ./src/kafka/Dockerfile
+            tag_suffix: kafka
+            context: ./
+            setup-qemu: true
+          - file: ./src/loadgenerator/Dockerfile
+            tag_suffix: loadgenerator
+            context: ./
+            setup-qemu: true
+          - file: ./src/paymentservice/Dockerfile
+            tag_suffix: paymentservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/productcatalogservice/Dockerfile
+            tag_suffix: productcatalogservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/quoteservice/Dockerfile
+            tag_suffix: quoteservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/recommendationservice/Dockerfile
+            tag_suffix: recommendationservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/shippingservice/Dockerfile
+            tag_suffix: shippingservice
+            context: ./
+            setup-qemu: true
+          - file: ./src/flagd-ui/Dockerfile
+            tag_suffix: flagdui
+            context: ./
+            setup-qemu: true
+          - file: ./test/tracetesting/Dockerfile
+            tag_suffix: traceBasedTests
+            context: ./
+            setup-qemu: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Load environment variables from .env file
+        run: |
+          if [ -f .env ]; then
+            # Filter out comments and empty lines, then add each variable to $GITHUB_ENV
+            grep -vE '^\s*#|^\s*$' .env | while read -r line; do
+              echo "$line" >> $GITHUB_ENV
+            done
+          else
+            echo ".env file not found!"
+            exit 1
+          fi
+      - name: Check for changes and set push options
+        id: check_changes
+        run: |
+          DOCKERFILE_DIR=$(dirname ${{ matrix.file_tag.file }})
+          FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- $DOCKERFILE_DIR)
+          FORCE_PUSH=${{ inputs.push }}
+          if [ "$FORCE_PUSH" = true ]; then
+            echo "Force push is enabled, proceeding with build."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$FILES_CHANGED" ]; then
+            echo "No changes in ${{ matrix.file_tag.context }}, skipping build."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected in ${{ matrix.file_tag.context }}, proceeding with build."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ inputs.push }}
+      - name: Set up QEMU
+        if: ${{ matrix.file_tag.setup-qemu }}
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+            max-parallelism = 2
+      - name: Matrix Build and push demo images
+        if: steps.check_changes.outputs.skip == 'false'
+        uses: docker/build-push-action@v6.10.0
+        with:
+          context: ${{ matrix.file_tag.context }}
+          file: ${{ matrix.file_tag.file }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ inputs.push }}
+          build-args: |
+            OTEL_JAVA_AGENT_VERSION=${{ env.OTEL_JAVA_AGENT_VERSION }}
+            OPENTELEMETRY_CPP_VERSION=${{ env.OPENTELEMETRY_CPP_VERSION }}
+            TRACETEST_IMAGE_VERSION=${{ env.TRACETEST_IMAGE_VERSION }}
+          tags: |
+            ${{ inputs.ghcr_repo }}:${{ inputs.version }}-${{ matrix.file_tag.tag_suffix }}
+            ${{ inputs.ghcr_repo }}:latest-${{ matrix.file_tag.tag_suffix }}
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/release-multiplayer.yml
+++ b/.github/workflows/release-multiplayer.yml
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+name: "Build and Publish"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_and_push_images:
+    uses: ./.github/workflows/component-build-images-multiplayer.yml
+    if: github.repository == 'multiplayer-app/opentelemetry-demo'
+    with:
+      push: true
+      version: ${{ github.event.release.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
# Changes

Adds a GitHub action to publish our custom services images. The action will be triggered on each release. The workflow files are a copy of the upstream repository removing Dockerhub registry. Initially, we would be publishing the images to the repository Github image registry.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
